### PR TITLE
Replace deprecated exists methods

### DIFF
--- a/.github/workflows/gem-push.yml
+++ b/.github/workflows/gem-push.yml
@@ -1,0 +1,29 @@
+name: Build and Push Gem
+
+on:
+  push:
+    branches: [ master ]
+
+jobs:
+  build:
+    name: Build + Publish
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up Ruby 2.7
+      uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: 2.7
+
+    - name: Publish to Github Package Registry
+      run: |
+        mkdir -p $HOME/.gem
+        touch $HOME/.gem/credentials
+        chmod 0600 $HOME/.gem/credentials
+        printf -- "---\n:github: ${GEM_HOST_API_KEY}\n" > $HOME/.gem/credentials
+        gem build *.gemspec
+        gem push --KEY github --host https://rubygems.pkg.github.com/${OWNER} *.gem
+      env:
+        GEM_HOST_API_KEY: "Bearer ${{secrets.GITHUB_TOKEN}}"
+        OWNER: ${{ github.repository_owner }}

--- a/.github/workflows/gem-version-check.yml
+++ b/.github/workflows/gem-version-check.yml
@@ -1,0 +1,17 @@
+name: Verify Gem Version Change
+
+on:
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build:
+    name: Version Check
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Version Forget Me Not
+      uses: simplybusiness/version-forget-me-not@v2
+      env:
+        ACCESS_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        VERSION_FILE_PATH: "lib/hologram/version.rb"

--- a/lib/hologram/doc_builder.rb
+++ b/lib/hologram/doc_builder.rb
@@ -27,7 +27,7 @@ module Hologram
     end
 
     def self.setup_dir
-      if File.exists?("hologram_config.yml")
+      if File.exist?("hologram_config.yml")
         DisplayMessage.warning("Cowardly refusing to overwrite existing hologram_config.yml")
         return
       end
@@ -250,18 +250,18 @@ module Hologram
     def set_header_footer
       # load the markdown renderer we are going to use
 
-      if File.exists?("#{doc_assets_dir}/_header.html")
+      if File.exist?("#{doc_assets_dir}/_header.html")
         @header_erb = ERB.new(File.read("#{doc_assets_dir}/_header.html"))
-      elsif File.exists?("#{doc_assets_dir}/header.html")
+      elsif File.exist?("#{doc_assets_dir}/header.html")
         @header_erb = ERB.new(File.read("#{doc_assets_dir}/header.html"))
       else
         @header_erb = nil
         DisplayMessage.warning("No _header.html found in documentation assets. Without this your css/header will not be included on the generated pages.")
       end
 
-      if File.exists?("#{doc_assets_dir}/_footer.html")
+      if File.exist?("#{doc_assets_dir}/_footer.html")
         @footer_erb = ERB.new(File.read("#{doc_assets_dir}/_footer.html"))
-      elsif File.exists?("#{doc_assets_dir}/footer.html")
+      elsif File.exist?("#{doc_assets_dir}/footer.html")
         @footer_erb = ERB.new(File.read("#{doc_assets_dir}/footer.html"))
       else
         @footer_erb = nil

--- a/lib/hologram/doc_parser.rb
+++ b/lib/hologram/doc_parser.rb
@@ -153,7 +153,7 @@ module Hologram
     end
 
     def is_supported_file_type?(file)
-      @supported_extensions.include?(File.extname(file)) and !Dir.exists?(file)
+      @supported_extensions.include?(File.extname(file)) and !Dir.exist?(file)
     end
 
     def get_file_name(str)

--- a/lib/hologram/version.rb
+++ b/lib/hologram/version.rb
@@ -25,5 +25,5 @@
 # ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 module Hologram
-  VERSION = "1.4.0"
+  VERSION = "1.4.1"
 end

--- a/spec/doc_builder_spec.rb
+++ b/spec/doc_builder_spec.rb
@@ -111,13 +111,13 @@ describe Hologram::DocBuilder do
     end
 
     it 'creates a config file' do
-      expect(File.exists?('hologram_config.yml')).to be_truthy
+      expect(File.exist?('hologram_config.yml')).to be_truthy
     end
 
     it 'creates default assets' do
       Dir.chdir('doc_assets') do
         ['_header.html', '_footer.html'].each do |asset|
-          expect(File.exists?(asset)).to be_truthy
+          expect(File.exist?(asset)).to be_truthy
         end
       end
     end


### PR DESCRIPTION
Due to the deprecation of the `exists?` methods for the File and Dir classes in ruby 2.1, and eventual removal in ruby 3.2, this pull request replaces the calls to these methods with the "bare verb" `exist?` method.

[See Ruby 3.2 removals in the changelog.](https://rubyreferences.github.io/rubychanges/3.2.html#removals)